### PR TITLE
Fix missing null-coalescing operator

### DIFF
--- a/make_reports.R
+++ b/make_reports.R
@@ -3,6 +3,13 @@ library(yaml)
 library("tidyverse")
 library("rmarkdown")
 
+# Define a simple null-coalescing operator to avoid relying on additional
+# packages. This returns the left-hand side if it is not NULL, otherwise the
+# right-hand side.
+`%||%` <- function(x, y) {
+  if (!is.null(x)) x else y
+}
+
 # read arguments
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) == 0 || "--help" %in% args) {

--- a/make_reports_parallel_logs.R
+++ b/make_reports_parallel_logs.R
@@ -18,6 +18,12 @@ invisible(lapply(required_packages, function(pkg) {
   suppressPackageStartupMessages(library(pkg, character.only = TRUE))
 }))
 
+# Provide a simple null-coalescing operator (`%||%`) locally so the script
+# does not rely on rlang being attached when run as a standalone script.
+`%||%` <- function(x, y) {
+  if (!is.null(x)) x else y
+}
+
 
  # read arguments
 args <- commandArgs(trailingOnly = TRUE)


### PR DESCRIPTION
## Summary
- Define a local `%||%` helper in both report-generation scripts to avoid relying on `rlang`

## Testing
- `Rscript make_reports.R mock_files/config.yaml` *(fails: there is no package called ‘yaml’)*
- `Rscript -e 'install.packages(c("yaml","tidyverse","rmarkdown"), repos="https://cloud.r-project.org")'` *(fails: packages are not available for this version of R)*

------
https://chatgpt.com/codex/tasks/task_e_68952225ab24832aa03b2d7526603a5a